### PR TITLE
Fix change tracking for large files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ooxml-viewer",
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "keywords": [
     "ooxml",
     "oxml",
-    "open office xml",
     "office open xml"
   ],
   "engines": {

--- a/src/extension-utilities.ts
+++ b/src/extension-utilities.ts
@@ -113,7 +113,6 @@ export class ExtensionUtilities {
       msg = err.message;
     }
 
-    console.error(msg);
     await window.showErrorMessage(msg);
   }
 }

--- a/src/extension-utilities.ts
+++ b/src/extension-utilities.ts
@@ -1,4 +1,4 @@
-import { commands, env, Position, Range, TextDocument, TextEditor, TextEditorEdit, window } from 'vscode';
+import { commands, env, FileSystemError, Position, Range, TextDocument, TextEditor, TextEditorEdit, window } from 'vscode';
 
 export class ExtensionUtilities {
   /**
@@ -68,7 +68,7 @@ export class ExtensionUtilities {
         }
       }
     } catch (err) {
-      console.error(err);
+      this.handleError(err);
     }
   }
 
@@ -105,14 +105,19 @@ export class ExtensionUtilities {
   }
 
   static async handleError(err: unknown): Promise<void> {
-    let msg = 'unknown error';
+    try {
+      let msg = 'unknown error';
 
-    if (typeof err === 'string') {
-      msg = err;
-    } else if (err instanceof Error) {
-      msg = err.message;
+      if (typeof err === 'string') {
+        msg = err;
+      } else if (err instanceof Error) {
+        msg = err.message;
+      }
+
+      await window.showErrorMessage(msg);
+    } catch(error) {
+      const msg = (error as Error)?.message || (error as FileSystemError)?.code || 'unknown error';
+      throw new Error(msg);
     }
-
-    await window.showErrorMessage(msg);
   }
 }

--- a/src/extension-utilities.ts
+++ b/src/extension-utilities.ts
@@ -103,4 +103,17 @@ export class ExtensionUtilities {
       }
     }
   }
+
+  static async handleError(err: unknown): Promise<void> {
+    let msg = 'unknown error';
+
+    if (typeof err === 'string') {
+      msg = err;
+    } else if (err instanceof Error) {
+      msg = err.message;
+    }
+
+    console.error(msg);
+    await window.showErrorMessage(msg);
+  }
 }

--- a/src/ooxml-file-cache.ts
+++ b/src/ooxml-file-cache.ts
@@ -322,11 +322,7 @@ export class OOXMLFileCache {
    */
   async readFile(cachedFilePath: string): Promise<Uint8Array> {
     try {
-      if (existsSync(cachedFilePath)) {
-        return await workspace.fs.readFile(Uri.file(cachedFilePath));
-      }
-
-      return new Uint8Array();
+      return await workspace.fs.readFile(Uri.file(cachedFilePath));
     } catch (err) {
       await ExtensionUtilities.handleError(err);
     }

--- a/src/ooxml-file-cache.ts
+++ b/src/ooxml-file-cache.ts
@@ -285,17 +285,14 @@ export class OOXMLFileCache {
    * @param {boolean} fileContents The file contents.
    * @returns {Promise<void>}
    */
-  async writeFile(cachedFilePath: string, fileContents: Uint8Array, throwErrorForType?: string): Promise<void> {
+  async writeFile(cachedFilePath: string, fileContents: Uint8Array, throwError?: boolean): Promise<void> {
     try {
       await workspace.fs.createDirectory(Uri.file(dirname(cachedFilePath)));
       await workspace.fs.writeFile(Uri.file(cachedFilePath), fileContents);
     } catch (err) {
       const e = (err as FileSystemError);
 
-      if (
-        throwErrorForType &&
-        (e?.code.toLowerCase() === throwErrorForType.toLowerCase() || e?.message.toLowerCase().includes(throwErrorForType.toLowerCase()))
-      ) {
+      if (throwError) {
         throw e;
       } else {
         await ExtensionUtilities.handleError(err);

--- a/src/ooxml-file-cache.ts
+++ b/src/ooxml-file-cache.ts
@@ -325,7 +325,11 @@ export class OOXMLFileCache {
    */
   async readFile(cachedFilePath: string): Promise<Uint8Array> {
     try {
-      return await workspace.fs.readFile(Uri.file(cachedFilePath));
+      if (existsSync(cachedFilePath)) {
+        return await workspace.fs.readFile(Uri.file(cachedFilePath));
+      }
+
+      return new Uint8Array();
     } catch (err) {
       await ExtensionUtilities.handleError(err);
     }

--- a/src/ooxml-tree-view-provider.ts
+++ b/src/ooxml-tree-view-provider.ts
@@ -138,7 +138,7 @@ export class FileNode implements TreeItem {
   setDeleted(): void {
     this._status = 'deleted';
   }
-  
+
   /**
    * Sets the status of the file node to modified.
    */

--- a/src/ooxml-viewer.ts
+++ b/src/ooxml-viewer.ts
@@ -211,6 +211,7 @@ export class OOXMLViewer {
     try {
       await workspace.fs.stat(Uri.file(this.cache.normalSubfolderPath));
       const searchTerm = await window.showInputBox({ title: 'Search OOXML Parts', prompt: 'Enter a search term.' });
+
       if (!searchTerm) {
         return;
       }
@@ -223,10 +224,7 @@ export class OOXMLViewer {
         matchWholeWord: false,
       });
     } catch (err) {
-      if (
-        Object.prototype.hasOwnProperty.call(err, 'code') &&
-        ((err as FileSystemError)?.code.toLowerCase() === 'enoent' || (err as FileSystemError)?.code.toLowerCase() === 'filenotfound')
-      ) {
+      if ((err as FileSystemError)?.code?.toLowerCase() === 'filenotfound') {
         window.showWarningMessage(warningMsg);
       } else {
         await ExtensionUtilities.handleError(err);

--- a/src/ooxml-viewer.ts
+++ b/src/ooxml-viewer.ts
@@ -6,6 +6,7 @@ import {
   commands,
   Disposable,
   ExtensionContext,
+  FileSystemError,
   FileSystemWatcher,
   ProgressLocation,
   TextDocument,
@@ -95,8 +96,7 @@ export class OOXMLViewer {
         },
       );
     } catch (err) {
-      console.error(err);
-      await window.showErrorMessage(`Could not load ${file.fsPath}`, err);
+      await ExtensionUtilities.handleError(err);
     }
   }
 
@@ -124,9 +124,8 @@ export class OOXMLViewer {
           await commands.executeCommand('vscode.open', Uri.file(filePath));
         },
       );
-    } catch (e) {
-      console.error(e);
-      await window.showErrorMessage(`Could not load ${fileNode.fullPath}`);
+    } catch (err) {
+      await ExtensionUtilities.handleError(err);
     }
   }
 
@@ -167,8 +166,7 @@ export class OOXMLViewer {
 
       await commands.executeCommand('vscode.diff', Uri.file(fileCompareCachePath), Uri.file(fileCachePath), title);
     } catch (err) {
-      console.error(err.message || err);
-      await window.showErrorMessage(err.message || err);
+      await ExtensionUtilities.handleError(err);
     }
   }
 
@@ -215,12 +213,10 @@ export class OOXMLViewer {
         matchWholeWord: false,
       });
     } catch (err) {
-      if (err?.code === 'ENOENT' || err?.code === 'FileNotFound') {
+      if (err instanceof FileSystemError && (err?.code === 'ENOENT' || err?.code === 'FileNotFound')) {
         window.showWarningMessage(warningMsg);
       } else {
-        const msg = err.message || err;
-        console.error(msg);
-        window.showErrorMessage(msg);
+        await ExtensionUtilities.handleError(err);
       }
     }
   }
@@ -276,8 +272,7 @@ export class OOXMLViewer {
 
       await Promise.all([this.closeEditors(), this.cache.clear()]);
     } catch (err) {
-      console.error(err);
-      await window.showErrorMessage('Could not remove ooxml file viewer cache');
+      await ExtensionUtilities.handleError(err);
     }
   }
 
@@ -415,8 +410,7 @@ export class OOXMLViewer {
 
           await this.populateOOXMLViewer(this.zip.files, true);
         } catch (err) {
-          console.error(err.message);
-          await window.showErrorMessage(err.message || err);
+          await ExtensionUtilities.handleError(err);
         }
       },
     );
@@ -456,8 +450,7 @@ export class OOXMLViewer {
 
       this.treeDataProvider.refresh();
     } catch (err) {
-      console.error(err.message || err);
-      await window.showErrorMessage(err.message || err);
+      await ExtensionUtilities.handleError(err);
     }
   }
 
@@ -479,7 +472,7 @@ export class OOXMLViewer {
           try {
             await this.tryFormatXml(filePath);
           } catch (err) {
-            console.error(err);
+            await ExtensionUtilities.handleError(err);
           }
         });
 
@@ -491,8 +484,7 @@ export class OOXMLViewer {
           await commands.executeCommand('workbench.action.closeActiveEditor');
         });
     } catch (err) {
-      console.error(err.message || err);
-      await window.showErrorMessage(err.message || err);
+      await ExtensionUtilities.handleError(err);
     }
   }
 
@@ -538,8 +530,7 @@ export class OOXMLViewer {
       const minPrevFileText = vkBeautify.xmlmin(prevFileText);
       return minFileText !== minPrevFileText;
     } catch (err) {
-      console.error(err.message || err);
-      await window.showErrorMessage(err.message || err);
+      await ExtensionUtilities.handleError(err);
     }
 
     return false;

--- a/src/ooxml-viewer.ts
+++ b/src/ooxml-viewer.ts
@@ -86,15 +86,13 @@ export class OOXMLViewer {
             new RelativePattern(dirname(file.fsPath), basename(file.fsPath)),
           );
 
-          let trackingTimer: number;
+          let locked = false;
 
           watcher.onDidChange(async (uri: Uri) => {
-            const now = Date.now();
-
-            if (!trackingTimer || now - trackingTimer > 1000) {
-              trackingTimer = now;
-
+            if (!locked) {
+              locked = true;
               await this.reloadOoxmlFile(file.fsPath);
+              locked = false;
             }
           });
 

--- a/test/suite/ooxml-viewer.test.ts
+++ b/test/suite/ooxml-viewer.test.ts
@@ -185,14 +185,12 @@ suite('OOXMLViewer', async function () {
     const err = new Error('Pants on backwards');
     const encoderStub = stub(ooxmlViewer.textDecoder, 'decode').throws(err);
     const getCachedFileStub = stub(ooxmlViewer.cache, 'getCachedFile').returns(Promise.resolve(new Uint8Array()));
-    const consoleErrorStub = stub(console, 'error');
     const showErrorStub = stub(window, 'showErrorMessage');
 
-    stubs.push(encoderStub, consoleErrorStub, showErrorStub, getCachedFileStub);
+    stubs.push(encoderStub, showErrorStub, getCachedFileStub);
 
     await ooxmlViewer.getDiff(new FileNode());
 
-    expect(consoleErrorStub.args[0][0]).to.eq(err.message);
     expect(showErrorStub.args[0][0]).to.eq(err.message);
   });
 
@@ -280,12 +278,10 @@ suite('OOXMLViewer', async function () {
   test('searchOoxmlParts should console.error and window.showErrorMessage an error if an error is thrown', async function () {
     const err = new Error('out of tacos');
     const showInputStub = stub(window, 'showInputBox').returns(Promise.reject(err));
-    const consoleErrorStub = stub(console, 'error');
     const showErrorMessageStub = stub(window, 'showErrorMessage');
-    stubs.push(showInputStub, consoleErrorStub, showErrorMessageStub);
+    stubs.push(showInputStub, showErrorMessageStub);
 
     await ooxmlViewer.searchOoxmlParts();
-    expect(consoleErrorStub.args[0][0]).to.eq(err.message);
     expect(showErrorMessageStub.args[0][0]).to.eq(err.message);
   });
 

--- a/test/suite/ooxml-viewer.test.ts
+++ b/test/suite/ooxml-viewer.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'os';
 import { join, sep } from 'path';
 import { match, SinonStub, spy, stub } from 'sinon';
 import { TextDecoder } from 'util';
-import { commands, Disposable, ExtensionContext, TextDocument, TextDocumentShowOptions, TextEditor, Uri, window } from 'vscode';
+import { commands, Disposable, ExtensionContext, FileSystemError, TextDocument, TextDocumentShowOptions, TextEditor, Uri, window } from 'vscode';
 import xmlFormatter from 'xml-formatter';
 import { CACHE_FOLDER_NAME, NORMAL_SUBFOLDER_NAME } from '../../src/ooxml-file-cache';
 import { FileNode, OOXMLTreeDataProvider } from '../../src/ooxml-tree-view-provider';
@@ -31,15 +31,18 @@ suite('OOXMLViewer', async function () {
     stubs.length = 0;
   });
 
-  test('searchOoxmlParts should return and not perform a search if no search term is entered', async function () {
+  test('searchOoxmlParts should return and not perform a search if no search term is entered', function (done) {
     const showInputStub = stub(window, 'showInputBox').returns(Promise.resolve(''));
     const tryFormatXmlStub = stub(ooxmlViewer, <never>'tryFormatXml');
     const executeCommandStub = stub(commands, 'executeCommand');
     stubs.push(showInputStub, tryFormatXmlStub, executeCommandStub);
 
-    await ooxmlViewer.searchOoxmlParts();
-    expect(tryFormatXmlStub.callCount).to.eq(0);
-    expect(executeCommandStub.callCount).to.eq(0);
+    ooxmlViewer.searchOoxmlParts()
+      .then(() => {
+        expect(tryFormatXmlStub.callCount).to.eq(0);
+        expect(executeCommandStub.callCount).to.eq(0);
+        done();
+      });
   });
 
   test('should have an instance of OOXMLTreeDataProvider', function () {
@@ -275,45 +278,34 @@ suite('OOXMLViewer', async function () {
     });
   });
 
-  test('searchOoxmlParts should console.error and window.showErrorMessage an error if an error is thrown', async function () {
+  test('searchOoxmlParts should call window.showErrorMessage with an error if an error is thrown', function (done) {
     const err = new Error('out of tacos');
-    const showInputStub = stub(window, 'showInputBox').returns(Promise.reject(err));
+    const showInputStub = stub(window, 'showInputBox').throws(err);
     const showErrorMessageStub = stub(window, 'showErrorMessage');
+
     stubs.push(showInputStub, showErrorMessageStub);
 
-    await ooxmlViewer.searchOoxmlParts();
-    expect(showErrorMessageStub.args[0][0]).to.eq(err.message);
+    ooxmlViewer.searchOoxmlParts()
+      .then(() => {
+        expect(showErrorMessageStub.args[0][0]).to.eq(err.message);
+        done();
+      })
+      .catch((error: unknown) => {
+        done(error);
+      });
   });
 
-  class VSError extends Error {
-    code: string;
-
-    constructor(data: { code: string }) {
-      super();
-      this.code = data.code;
-    }
-  }
-
-  test('searchOoxmlParts should window.showWarningMessage if no file is open in the viewer with ENOENT', async function () {
-    const err = new VSError({ code: 'ENOENT' });
+  test('searchOoxmlParts should window.showWarningMessage if no file is open in the viewer with FileNotFound', function (done) {
     const msg = 'A file must be open in the OOXML Viewer to search its parts.';
-    const showInputStub = stub(window, 'showInputBox').returns(Promise.reject(err));
+    const showInputStub = stub(window, 'showInputBox').throws(FileSystemError.FileNotFound);
     const showWarningMessageStub = stub(window, 'showWarningMessage');
     stubs.push(showInputStub, showWarningMessageStub);
 
-    await ooxmlViewer.searchOoxmlParts();
-    expect(showWarningMessageStub.args[0][0]).to.eq(msg);
-  });
-
-  test('searchOoxmlParts should window.showWarningMessage if no file is open in the viewer with FileNotFound', async function () {
-    const err = new VSError({ code: 'FileNotFound' });
-    const msg = 'A file must be open in the OOXML Viewer to search its parts.';
-    const showInputStub = stub(window, 'showInputBox').returns(Promise.reject(err));
-    const showWarningMessageStub = stub(window, 'showWarningMessage');
-    stubs.push(showInputStub, showWarningMessageStub);
-
-    await ooxmlViewer.searchOoxmlParts();
-    expect(showWarningMessageStub.args[0][0]).to.eq(msg);
+    ooxmlViewer.searchOoxmlParts()
+      .then(() => {
+        expect(showWarningMessageStub.args[0][0]).to.eq(msg);
+        done();
+      });
   });
 
   test('tryFormatDocument should format document if it belongs to the normal cache path', async () => {


### PR DESCRIPTION
This fixes issue #27 . The `FileSystemWatcher.onDidChange` event can be triggered multiple times on larger files such as .pptx. This commit adds a timer to the `FileSystemWatcher.onDidChange` event to prevent multiple comparison operations. 