### PR TITLE
Fix issue where extension could delete all files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Issue where extension could recursively delete all files [#48](https://github.com/yuenm18/ooxml-viewer-vscode/issues/48)
+
 ## [2.0.2] - 2024-12-12
 
 ### Fixed

--- a/src/ooxml-viewer.ts
+++ b/src/ooxml-viewer.ts
@@ -14,7 +14,12 @@ export class OOXMLViewer {
   private ooxmlPackages: OOXMLPackageFacade[];
 
   private get contextStorageUri() {
-    return this.context.storageUri?.fsPath || '';
+    return (
+      this.context.storageUri?.fsPath ??
+      (() => {
+        throw new Error('Storage URI does not exist');
+      })()
+    );
   }
 
   /**

--- a/src/utilities/file-system-utilities.ts
+++ b/src/utilities/file-system-utilities.ts
@@ -1,4 +1,6 @@
+import assert from 'assert';
 import { FileSystemError, Uri, workspace } from 'vscode';
+import packageJson from '../../package.json';
 import logger from './logger';
 
 /**
@@ -67,6 +69,7 @@ export class FileSystemUtilities {
    */
   static async deleteFile(filePath: string): Promise<void> {
     logger.trace(`Deleting file '${filePath}'`);
+    assert.ok(filePath.includes(packageJson.name), "Attempting to delete a file that doesn't belong to the extension");
     await workspace.fs.delete(Uri.file(filePath), { recursive: true, useTrash: false });
   }
 

--- a/test/suite/ooxml-viewer.test.ts
+++ b/test/suite/ooxml-viewer.test.ts
@@ -124,4 +124,20 @@ suite('OOXMLViewer', async function () {
     expect(ooxmlPackage.dispose.callCount).to.be.eq(1);
     expect(deleteFileStub.callCount).to.be.eq(1);
   });
+
+  test('reset should not call deleteFile if there is no storageUri', async function () {
+    const context = {
+      storageUri: null,
+      subscriptions: [],
+    } as unknown as ExtensionContext;
+    const treeViewDataProvider = createStubInstance(OOXMLTreeDataProvider);
+    treeViewDataProvider.rootFileNode = new FileNode();
+    const ooxmlViewer = new OOXMLViewer(treeViewDataProvider, settings, context);
+    const deleteFileStub = stub(FileSystemUtilities, 'deleteFile').returns(Promise.resolve());
+    stubs.push(deleteFileStub);
+
+    await ooxmlViewer.reset();
+
+    expect(deleteFileStub.callCount).to.be.eq(0);
+  });
 });


### PR DESCRIPTION
Throw if `storageUri` is not set instead of falling back to ''. `storageUri` is undefined if no folder is open in vscode (https://vscode-api.js.org/interfaces/vscode.ExtensionContext.html#storageUri).

Add an assertion in the deleteFile() utility method to ensure deletes only work on paths that include the name of the extension.

Fixes #48