### PR TITLE
detect macOS "safe-save" events from PowerPoint

### DIFF
--- a/src/ooxml-package/ooxml-package-file-watcher.ts
+++ b/src/ooxml-package/ooxml-package-file-watcher.ts
@@ -1,5 +1,5 @@
 import { basename, dirname } from 'path';
-import { Disposable, FileSystemWatcher, RelativePattern, workspace } from 'vscode';
+import { Disposable, FileSystemWatcher, RelativePattern, Uri, workspace } from 'vscode';
 import logger from '../utilities/logger';
 import { OOXMLPackage } from './ooxml-package';
 
@@ -39,7 +39,7 @@ export class OOXMLPackageFileWatcher {
     // Prevents multiple file system watcher triggers from unmodified files
     let stats = { mtime: 0 };
 
-    fileSystemWatcher.onDidChange(async uri => {
+    const handleExternalChange = async (uri: Uri) => {
       logger.trace(`File system did change triggered`);
       const newStats = await workspace.fs.stat(uri);
 
@@ -56,6 +56,14 @@ export class OOXMLPackageFileWatcher {
       } else {
         logger.debug('File system watcher locked');
       }
+    };
+
+    fileSystemWatcher.onDidChange(async uri => {
+      handleExternalChange(uri);
+    });
+
+    fileSystemWatcher.onDidCreate(async uri => {
+      handleExternalChange(uri);
     });
 
     fileSystemWatcher.onDidDelete(async uri => {


### PR DESCRIPTION
### Problem
On macOS, PowerPoint saves a file by writing it as a temp copy, deleting the original, and then renaming the temp file.

VSCode emits this sequence as an `onDidCreate` event, not `onDidChange`, so the OOXML-Viewer never reloads the package, and the status icons stay stale.

The new handler routes create events using the same logic that has already been changed.

This change should fix #36 

### Impact
- macOS + PowerPoint: icons now refresh immediately after every save.
- Windows/Linux: unchanged (they still raise change).
- No extra dependencies or behavioural differences elsewhere.