### PR TITLE
Use xml-formatter for minify

### DIFF
--- a/src/utilities/xml-formatter.ts
+++ b/src/utilities/xml-formatter.ts
@@ -42,11 +42,10 @@ export class XmlFormatter {
     }
 
     const text = textDecoder.decode(data);
-    const xml = preserveComments
-      ? text
-      : text.replace(/\<![ \r\n\t]*(--([^\-]|[\r\n]|-[^\-])*--[ \r\n\t]*)\>/g, '').replace(/[ \r\n\t]{1,}xmlns/g, ' xmlns');
-
-    const minifiedXml = xml.replace(/>\s{0,}</g, '><');
+    const minifiedXml = xmlFormatter.minify(text, {
+      filter: preserveComments ? undefined : node => node.type !== 'Comment',
+      collapseContent: true,
+    });
 
     return textEncoder.encode(minifiedXml);
   }

--- a/test/suite/ooxml-package/ooxml-package.test.ts
+++ b/test/suite/ooxml-package/ooxml-package.test.ts
@@ -237,7 +237,7 @@ suite('OOXMLPackage', async function () {
         {
           filePath: 'doc/document.xml',
           isDirectory: false,
-          data: new TextEncoder().encode('<?xml?>'),
+          data: new TextEncoder().encode('<?xml?><Root/>'),
         },
       ];
       const fileNode = new FileNode();
@@ -278,7 +278,7 @@ suite('OOXMLPackage', async function () {
         {
           filePath: 'document.xml',
           isDirectory: false,
-          data: new TextEncoder().encode('<?xml?>'),
+          data: new TextEncoder().encode('<?xml?><Root/>'),
         },
       ];
       const fileNode = new FileNode();
@@ -296,7 +296,7 @@ suite('OOXMLPackage', async function () {
         {
           filePath: 'document.xml',
           isDirectory: false,
-          data: new TextEncoder().encode('<?xml?>'),
+          data: new TextEncoder().encode('<?xml?><Root/>'),
         },
       ];
       const fileNode = new FileNode();
@@ -316,13 +316,13 @@ suite('OOXMLPackage', async function () {
         {
           filePath: 'document.xml',
           isDirectory: false,
-          data: new TextEncoder().encode('<?xml?>'),
+          data: new TextEncoder().encode('<?xml?><NewRoot/>'),
         },
       ];
       const fileNode = new FileNode();
       ooxmlFileAccessor.getPackageContents.onCall(0).returns(Promise.resolve(packageContents));
       ooxmlFileAccessor.getPackageContents.onCall(1).returns(Promise.resolve(packageContents));
-      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><></>')));
+      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><Root/>')));
       ooxmlPackageTreeView.getRootFileNode.returns(fileNode);
 
       await ooxmlPackage.openOOXMLPackage();
@@ -337,7 +337,7 @@ suite('OOXMLPackage', async function () {
         {
           filePath: 'document.xml',
           isDirectory: false,
-          data: new TextEncoder().encode('<?xml?>'),
+          data: new TextEncoder().encode('<?xml?><Root/>'),
         },
       ];
       const fileNode = new FileNode();
@@ -357,7 +357,7 @@ suite('OOXMLPackage', async function () {
         {
           filePath: 'document.xml',
           isDirectory: false,
-          data: new TextEncoder().encode('<?xml?>'),
+          data: new TextEncoder().encode('<?xml?><Root/>'),
         },
       ];
       const fileNode = new FileNode();
@@ -379,7 +379,7 @@ suite('OOXMLPackage', async function () {
         {
           filePath: 'document.xml',
           isDirectory: false,
-          data: new TextEncoder().encode('<?xml?>'),
+          data: new TextEncoder().encode('<?xml?><Root/>'),
         },
       ];
       const fileNode = new FileNode();
@@ -411,8 +411,8 @@ suite('OOXMLPackage', async function () {
   suite('updateOOXMLPackage', () => {
     test('should update ooxml if there is a difference between the normal and the prev files', async function () {
       cache.cachePathIsNormal.returns(true);
-      cache.getCachedNormalFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?>')));
-      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><></>')));
+      cache.getCachedNormalFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><ModifiedRoot/>')));
+      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><Root/>')));
       ooxmlFileAccessor.updatePackage.returns(Promise.resolve(true));
 
       await ooxmlPackage.updateOOXMLFile('file/path');
@@ -422,8 +422,8 @@ suite('OOXMLPackage', async function () {
 
     test('should not update ooxml if the cache path does not belong to the ', async function () {
       cache.cachePathIsNormal.returns(false);
-      cache.getCachedNormalFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?>')));
-      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><></>')));
+      cache.getCachedNormalFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><ModifiedRoot/>')));
+      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><Root/>')));
       ooxmlFileAccessor.updatePackage.returns(Promise.resolve(true));
 
       await ooxmlPackage.updateOOXMLFile('file/path');
@@ -433,8 +433,8 @@ suite('OOXMLPackage', async function () {
 
     test('should not update ooxml if there is no difference between the normal and the prev files', async function () {
       cache.cachePathIsNormal.returns(true);
-      cache.getCachedNormalFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?>')));
-      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?>')));
+      cache.getCachedNormalFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><Root/>')));
+      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><Root/>')));
       ooxmlFileAccessor.updatePackage.returns(Promise.resolve(true));
 
       await ooxmlPackage.updateOOXMLFile('file/path');
@@ -444,8 +444,8 @@ suite('OOXMLPackage', async function () {
 
     test('should make editor dirty and displays warning if update package call fails', async function () {
       cache.cachePathIsNormal.returns(true);
-      cache.getCachedNormalFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?>')));
-      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><></>')));
+      cache.getCachedNormalFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><ModifiedRoot/>')));
+      cache.getCachedPrevFile.returns(Promise.resolve(new TextEncoder().encode('<?xml?><Root/>')));
       ooxmlFileAccessor.updatePackage.returns(Promise.resolve(false));
       const makeDirtyStub = stub(ExtensionUtilities, 'makeActiveTextEditorDirty').returns(Promise.resolve());
       const showWarningStub = stub(ExtensionUtilities, 'showWarning').returns(Promise.resolve());

--- a/test/suite/utilities/xml-formatter.test.ts
+++ b/test/suite/utilities/xml-formatter.test.ts
@@ -52,7 +52,7 @@ suite('OOXMLViewer Xml Formatter', function () {
     },
     {
       description: 'contents are not the same when minified',
-      content1: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`,
+      content1: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Root/>`,
       content2: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
 </Types>`,
@@ -75,17 +75,17 @@ suite('OOXMLViewer Xml Formatter', function () {
   var minifyTests = [
     {
       preserveComments: true,
-      raw: `<?xml ?><!-- comment -->
+      raw: `<?xml?><!-- comment -->
 <Types>
 </Types>`,
-      minified: `<?xml ?><!-- comment --><Types></Types>`,
+      minified: `<?xml?><!-- comment --><Types></Types>`,
     },
     {
       preserveComments: false,
-      raw: `<?xml ?><!-- comment -->
+      raw: `<?xml?><!-- comment -->
 <Types>
 </Types>`,
-      minified: `<?xml ?><Types></Types>`,
+      minified: `<?xml?><Types></Types>`,
     },
   ];
 
@@ -96,6 +96,39 @@ suite('OOXMLViewer Xml Formatter', function () {
       const rawData = encoder.encode(args.raw);
 
       const minified = XmlFormatter.minify(rawData, args.preserveComments);
+
+      expect(decoder.decode(minified)).to.equal(args.minified);
+    });
+  });
+
+  var minifySpaceTests = [
+    {
+      description: 'xml:space is honored',
+      preserveComments: true,
+      raw: `<?xml?><BlankText xml:space="preserve">  </BlankText>`,
+      minified: `<?xml?><BlankText xml:space="preserve">  </BlankText>`,
+    },
+    {
+      description: 'xml:space is honored',
+      preserveComments: false,
+      raw: `<?xml?><BlankText xml:space="preserve">  </BlankText>`,
+      minified: `<?xml?><BlankText xml:space="preserve">  </BlankText>`,
+    },
+    {
+      description: 'xml:space is honored even if not the only attribute',
+      preserveComments: true,
+      raw: `<?xml?><BlankText xml:space="preserve" otherattr="attrval">  </BlankText>`,
+      minified: `<?xml?><BlankText xml:space="preserve" otherattr="attrval">  </BlankText>`,
+    },
+  ];
+
+  minifySpaceTests.forEach(function (args) {
+    test(`minify when preserve comments is ${args.preserveComments} ${args.description}`, function () {
+      const encoder = new TextEncoder();
+      const decoder = new TextDecoder();
+      const rawData = encoder.encode(args.raw);
+
+      const minified = XmlFormatter.minify(rawData, true);
 
       expect(decoder.decode(minified)).to.equal(args.minified);
     });


### PR DESCRIPTION
Thanks for creating this extension.

I found a minor problem.

I had a document where some runs contained only whitespaces. 
`              <w:t xml:space="preserve">  </w:t>`
After saving in ooxml-viewer the whitespaces disappeared.

The current regex minifier can't handle this. Fortunately the already used xml-formatter package can minify too and it understands xml:space.

For tests I had to add a root element to all xml sample contents, because the new minifier throws without it.
